### PR TITLE
Add dark hover to menu items

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -481,6 +481,7 @@ a {
 }
 #main-navigation ul li a:hover {
   color: black;
+  background-color: #d3d3d3;
 }
 @media screen and (max-width: 991px) and (min-width: 767px) {
   #main-navigation ul li a {


### PR DESCRIPTION
This should cover the parent menu item.  Not sure the of the child dropdown items?   

Would this suffice for children item?
#main-navigation ul li ul a:hover {
  color: black;
  background-color: #d3d3d3;
}